### PR TITLE
fix : watchList가 빈 경우 발생하는 에러 수정

### DIFF
--- a/src/actions/startWatch.ts
+++ b/src/actions/startWatch.ts
@@ -23,6 +23,11 @@ export const startWatch = (client: Client<boolean>) => {
 
         for await (const channel of channels) {
           const { textChannel, watchList } = channel
+
+          if (!watchList || watchList.length === 0) {
+            continue
+          }
+
           const targetChannel = (await client.channels.fetch(
             textChannel,
           )) as TextChannel
@@ -67,9 +72,11 @@ export const startWatch = (client: Client<boolean>) => {
             embedsToSend.push(SearchEmbedBuilder(data))
           }
 
-          targetChannel.send({
-            embeds: embedsToSend,
-          })
+          if (embedsToSend.length > 0) {
+            targetChannel.send({
+              embeds: embedsToSend,
+            })
+          }
         }
       } catch (error) {
         console.log(error)


### PR DESCRIPTION
- discordjs에서 메세지를 전송할 경우 빈 메세지를 전달할 수 없음.
- watchList가 빈 경우 빈 메세지를 전달하려고 시도하면 에러가 발생.
- 따라서, watchList가 빈 경우 빈 메세지를 전달하지 않도록 수정.